### PR TITLE
fix: Refactor cloning and caching workflow

### DIFF
--- a/internal/exec.go
+++ b/internal/exec.go
@@ -23,4 +23,6 @@ package internal
 // ExecManager manager responsible for exec operations.
 type ExecManager interface {
 	RunCmd(name string, args []string) error
+	RunCmdInDir(name string, args []string, cwd string) error
+	RunInTempDir(dir, pattern string, fn func(string) error) error
 }

--- a/internal/exec/exec_mock.go
+++ b/internal/exec/exec_mock.go
@@ -46,3 +46,35 @@ func (mr *MockExecManagerMockRecorder) RunCmd(name, args interface{}) *gomock.Ca
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunCmd", reflect.TypeOf((*MockExecManager)(nil).RunCmd), name, args)
 }
+
+// RunCmdInDir mocks base method.
+func (m *MockExecManager) RunCmdInDir(name string, args []string, cwd string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RunCmdInDir", name, args, cwd)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RunCmdInDir indicates an expected call of RunCmdInDir.
+func (mr *MockExecManagerMockRecorder) RunCmdInDir(name, args, cwd interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunCmdInDir", reflect.TypeOf((*MockExecManager)(nil).RunCmdInDir), name, args, cwd)
+}
+
+// RunInTempDir mocks base method.
+func (m *MockExecManager) RunInTempDir(dir, pattern string, fn func(string) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RunInTempDir", dir, pattern, fn)
+	if fn != nil {
+		ret0 := fn("stub")
+		return ret0
+	}
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RunInTempDir indicates an expected call of RunInTempDir.
+func (mr *MockExecManagerMockRecorder) RunInTempDir(dir, pattern, fn interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunInTempDir", reflect.TypeOf((*MockExecManager)(nil).RunInTempDir), dir, pattern, fn)
+}

--- a/internal/exec/exec_public_test.go
+++ b/internal/exec/exec_public_test.go
@@ -71,6 +71,41 @@ func (suite *ExecManagerPublicTestSuite) TestRunCmdReturnsError() {
 	assert.Contains(suite.T(), err.Error(), "not found")
 }
 
+func (suite *ExecManagerPublicTestSuite) TestRunCmdInDirOk() {
+	em := suite.NewTestExecManager(false)
+
+	err := em.RunCmdInDir("ls", []string{}, "/tmp")
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *ExecManagerPublicTestSuite) TestRunCmdInDirWithDebug() {
+	suite.T().Skip("cannot seem to capture Stdout when logging in em")
+
+	em := suite.NewTestExecManager(true)
+
+	err := em.RunCmdInDir("echo", []string{"-n", "foo"}, "/tmp")
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *ExecManagerPublicTestSuite) TestRunCmdInDirReturnsError() {
+	em := suite.NewTestExecManager(false)
+
+	err := em.RunCmdInDir("invalid", []string{"foo"}, "/tmp")
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "not found")
+}
+
+func (suite *ExecManagerPublicTestSuite) TestRunInTempDirOk() {
+	em := suite.NewTestExecManager(false)
+
+	dir := ""
+	pattern := "test"
+	fn := func(string) error { return nil }
+
+	err := em.RunInTempDir(dir, pattern, fn)
+	assert.NoError(suite.T(), err)
+}
+
 // In order for `go test` to run this suite, we need to create
 // a normal test function and pass our suite to suite.Run.
 func TestExecPublicTestSuite(t *testing.T) {

--- a/internal/git.go
+++ b/internal/git.go
@@ -23,7 +23,5 @@ package internal
 // GitManager manager responsible for Git operations.
 type GitManager interface {
 	Clone(gitURL string, cloneDir string) error
-	CloneByTag(gitURL string, gitTag string, cloneDir string) error
-	Reset(cloneDir string, gitSHA string) error
-	CheckoutIndex(dstDir string, cloneDir string) error
+	Worktree(cloneDir string, version string, dstDir string) error
 }

--- a/internal/git/git_mock.go
+++ b/internal/git/git_mock.go
@@ -16,6 +16,11 @@ type MockGitManager struct {
 	recorder *MockGitManagerMockRecorder
 }
 
+// Worktree implements internal.GitManager.
+func (*MockGitManager) Worktree(cloneDir string, version string, dstDir string) error {
+	panic("unimplemented")
+}
+
 // MockGitManagerMockRecorder is the mock recorder for MockGitManager.
 type MockGitManagerMockRecorder struct {
 	mock *MockGitManager
@@ -31,20 +36,6 @@ func NewMockGitManager(ctrl *gomock.Controller) *MockGitManager {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockGitManager) EXPECT() *MockGitManagerMockRecorder {
 	return m.recorder
-}
-
-// CheckoutIndex mocks base method.
-func (m *MockGitManager) CheckoutIndex(dstDir, cloneDir string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckoutIndex", dstDir, cloneDir)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CheckoutIndex indicates an expected call of CheckoutIndex.
-func (mr *MockGitManagerMockRecorder) CheckoutIndex(dstDir, cloneDir interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckoutIndex", reflect.TypeOf((*MockGitManager)(nil).CheckoutIndex), dstDir, cloneDir)
 }
 
 // Clone mocks base method.

--- a/internal/git/git_public_test.go
+++ b/internal/git/git_public_test.go
@@ -76,7 +76,7 @@ func (suite *GitManagerPublicTestSuite) SetupTest() {
 
 func (suite *GitManagerPublicTestSuite) TestCloneOk() {
 	suite.mockExec.EXPECT().
-		RunCmd("git", []string{"clone", suite.gitURL, suite.cloneDir}).
+		RunCmd("git", []string{"clone", "--bare", "--filter=blob:none", suite.gitURL, suite.cloneDir}).
 		Return(nil)
 
 	err := suite.gm.Clone(suite.gitURL, suite.cloneDir)
@@ -88,63 +88,6 @@ func (suite *GitManagerPublicTestSuite) TestCloneReturnsError() {
 	suite.mockExec.EXPECT().RunCmd(gomock.Any(), gomock.Any()).Return(errors)
 
 	err := suite.gm.Clone(suite.gitURL, suite.cloneDir)
-	assert.Error(suite.T(), err)
-}
-
-func (suite *GitManagerPublicTestSuite) TestCloneByTagOk() {
-	suite.mockExec.EXPECT().
-		RunCmd("git", []string{"clone", "--depth", "1", "--branch", suite.gitTag, suite.gitURL, suite.cloneDir}).
-		Return(nil)
-
-	err := suite.gm.CloneByTag(suite.gitURL, suite.gitTag, suite.cloneDir)
-	assert.NoError(suite.T(), err)
-}
-
-func (suite *GitManagerPublicTestSuite) TestCloneByTagReturnsError() {
-	errors := errors.New("tests error")
-	suite.mockExec.EXPECT().RunCmd(gomock.Any(), gomock.Any()).Return(errors)
-
-	err := suite.gm.CloneByTag(suite.gitURL, suite.gitTag, suite.cloneDir)
-	assert.Error(suite.T(), err)
-}
-
-func (suite *GitManagerPublicTestSuite) TestResetOk() {
-	suite.mockExec.EXPECT().
-		RunCmd("git", []string{"-C", suite.cloneDir, "reset", "--hard", suite.gitSHA})
-
-	err := suite.gm.Reset(suite.cloneDir, suite.gitSHA)
-	assert.NoError(suite.T(), err)
-}
-
-func (suite *GitManagerPublicTestSuite) TestResetReturnsError() {
-	errors := errors.New("tests error")
-	suite.mockExec.EXPECT().RunCmd(gomock.Any(), gomock.Any()).Return(errors)
-
-	err := suite.gm.Reset(suite.cloneDir, suite.gitSHA)
-	assert.Error(suite.T(), err)
-}
-
-func (suite *GitManagerPublicTestSuite) TestCheckoutIndexOk() {
-	cmdArgs := []string{
-		"-C",
-		suite.cloneDir,
-		"checkout-index",
-		"--force",
-		"--all",
-		"--prefix",
-		suite.dstDir + string(os.PathSeparator),
-	}
-	suite.mockExec.EXPECT().RunCmd("git", cmdArgs).Return(nil)
-
-	err := suite.gm.CheckoutIndex(suite.dstDir, suite.cloneDir)
-	assert.NoError(suite.T(), err)
-}
-
-func (suite *GitManagerPublicTestSuite) TestCheckoutIndexReturnsError() {
-	errors := errors.New("tests error")
-	suite.mockExec.EXPECT().RunCmd(gomock.Any(), gomock.Any()).Return(errors)
-
-	err := suite.gm.CheckoutIndex(suite.dstDir, suite.cloneDir)
 	assert.Error(suite.T(), err)
 }
 

--- a/internal/repositories/repositories_test.go
+++ b/internal/repositories/repositories_test.go
@@ -78,44 +78,6 @@ func (suite *RepositoriesTestSuite) SetupTest() {
 	suite.logger = slog.New(slog.NewTextHandler(os.Stdout, nil))
 }
 
-func (suite *RepositoriesTestSuite) TestgetCloneDirOk() {
-	repos := suite.NewTestRepositories(suite.giltDir)
-
-	got := repos.getCloneDir(
-		suite.giltDir,
-		config.Repository{
-			Git: "https://example.com/user/repo2.git",
-			SHA: "abc123",
-		},
-	)
-	assert.Equal(suite.T(), "/giltDir/https---example.com-user-repo2.git-abc123", got)
-}
-
-func (suite *RepositoriesTestSuite) TestgetCloneDirOkByTag() {
-	repos := suite.NewTestRepositories(suite.giltDir)
-
-	got := repos.getCloneDir(
-		suite.giltDir,
-		config.Repository{
-			Git: "https://example.com/user/repo2.git",
-			Tag: "v1.1",
-		},
-	)
-	assert.Equal(suite.T(), "/giltDir/https---example.com-user-repo2.git-v1.1", got)
-}
-
-func (suite *RepositoriesTestSuite) TestgetCloneHashOk() {
-	repos := suite.NewTestRepositories(suite.giltDir)
-
-	got := repos.getCloneHash(
-		config.Repository{
-			Git: "https://example.com/user/repo2.git",
-			SHA: "abc123",
-		},
-	)
-	assert.Equal(suite.T(), "https---example.com-user-repo2.git-abc123", got)
-}
-
 func (suite *RepositoriesTestSuite) TestgetCacheDir() {
 	repos := suite.NewTestRepositories(suite.giltDir)
 

--- a/internal/repository.go
+++ b/internal/repository.go
@@ -26,7 +26,7 @@ import (
 
 // RepositoryManager manager responsible for Repository operations.
 type RepositoryManager interface {
-	Clone(config config.Repository, cloneDir string) error
-	CheckoutIndex(config config.Repository, cloneDir string) error
+	Clone(config config.Repository, cloneDir string) (string, error)
+	Worktree(config config.Repository, cloneDir string, targetDir string) error
 	CopySources(config config.Repository, cloneDir string) error
 }

--- a/internal/repository/repository_mock.go
+++ b/internal/repository/repository_mock.go
@@ -34,26 +34,13 @@ func (m *MockRepositoryManager) EXPECT() *MockRepositoryManagerMockRecorder {
 	return m.recorder
 }
 
-// CheckoutIndex mocks base method.
-func (m *MockRepositoryManager) CheckoutIndex(config config.Repository, cloneDir string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckoutIndex", config, cloneDir)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CheckoutIndex indicates an expected call of CheckoutIndex.
-func (mr *MockRepositoryManagerMockRecorder) CheckoutIndex(config, cloneDir interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckoutIndex", reflect.TypeOf((*MockRepositoryManager)(nil).CheckoutIndex), config, cloneDir)
-}
-
 // Clone mocks base method.
-func (m *MockRepositoryManager) Clone(config config.Repository, cloneDir string) error {
+func (m *MockRepositoryManager) Clone(config config.Repository, cloneDir string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Clone", config, cloneDir)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Clone indicates an expected call of Clone.
@@ -74,4 +61,18 @@ func (m *MockRepositoryManager) CopySources(config config.Repository, cloneDir s
 func (mr *MockRepositoryManagerMockRecorder) CopySources(config, cloneDir interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopySources", reflect.TypeOf((*MockRepositoryManager)(nil).CopySources), config, cloneDir)
+}
+
+// Worktree mocks base method.
+func (m *MockRepositoryManager) Worktree(config config.Repository, cloneDir, targetDir string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Worktree", config, cloneDir, targetDir)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Worktree indicates an expected call of Worktree.
+func (mr *MockRepositoryManagerMockRecorder) Worktree(config, cloneDir, targetDir interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Worktree", reflect.TypeOf((*MockRepositoryManager)(nil).CopySources), config, cloneDir, targetDir)
 }

--- a/internal/repository/repository_public_test.go
+++ b/internal/repository/repository_public_test.go
@@ -85,13 +85,13 @@ func (suite *RepositoryPublicTestSuite) TestCloneOk() {
 		Git: suite.gitURL,
 		SHA: suite.gitSHA,
 	}
+	targetDir := filepath.Join(suite.cloneDir, filepath.Base(c.Git))
 
 	gomock.InOrder(
-		suite.mockGit.EXPECT().Clone(suite.gitURL, suite.cloneDir).Return(nil),
-		suite.mockGit.EXPECT().Reset(suite.cloneDir, suite.gitSHA).Return(nil),
+		suite.mockGit.EXPECT().Clone(suite.gitURL, targetDir).Return(nil),
 	)
 
-	err := repo.Clone(c, suite.cloneDir)
+	_, err := repo.Clone(c, suite.cloneDir)
 	assert.NoError(suite.T(), err)
 }
 
@@ -106,28 +106,9 @@ func (suite *RepositoryPublicTestSuite) TestCloneReturnsErrorWhenCloneErrors() {
 	errors := errors.New("tests error")
 	gomock.InOrder(
 		suite.mockGit.EXPECT().Clone(gomock.Any(), gomock.Any()).Return(errors),
-		suite.mockGit.EXPECT().Reset(gomock.Any(), gomock.Any()).Return(nil),
 	)
 
-	err := repo.Clone(c, suite.cloneDir)
-	assert.Error(suite.T(), err)
-}
-
-func (suite *RepositoryPublicTestSuite) TestCloneReturnsErrorWhenResetErrors() {
-	repo := suite.NewRepositoryManager()
-
-	c := config.Repository{
-		Git: suite.gitURL,
-		SHA: suite.gitSHA,
-	}
-
-	errors := errors.New("tests error")
-	gomock.InOrder(
-		suite.mockGit.EXPECT().Clone(gomock.Any(), gomock.Any()).Return(nil),
-		suite.mockGit.EXPECT().Reset(gomock.Any(), gomock.Any()).Return(errors),
-	)
-
-	err := repo.Clone(c, suite.cloneDir)
+	_, err := repo.Clone(c, suite.cloneDir)
 	assert.Error(suite.T(), err)
 }
 
@@ -138,44 +119,12 @@ func (suite *RepositoryPublicTestSuite) TestCloneDoesNotCloneWhenCloneDirExists(
 		Git: suite.gitURL,
 		SHA: suite.gitSHA,
 	}
+	targetDir := filepath.Join(suite.cloneDir, filepath.Base(c.Git))
 
-	_ = suite.appFs.MkdirAll(suite.cloneDir, 0o755)
+	_ = suite.appFs.MkdirAll(targetDir, 0o755)
 
-	err := repo.Clone(c, suite.cloneDir)
+	_, err := repo.Clone(c, suite.cloneDir)
 	assert.NoError(suite.T(), err)
-}
-
-func (suite *RepositoryPublicTestSuite) TestCloneByTagOk() {
-	repo := suite.NewRepositoryManager()
-
-	c := config.Repository{
-		Git: suite.gitURL,
-		Tag: suite.gitTag,
-	}
-
-	gomock.InOrder(
-		suite.mockGit.EXPECT().CloneByTag(suite.gitURL, suite.gitTag, suite.cloneDir).Return(nil),
-	)
-
-	err := repo.Clone(c, suite.cloneDir)
-	assert.NoError(suite.T(), err)
-}
-
-func (suite *RepositoryPublicTestSuite) TestCloneByTagReturnsError() {
-	repo := suite.NewRepositoryManager()
-
-	c := config.Repository{
-		Git: suite.gitURL,
-		Tag: suite.gitTag,
-	}
-
-	errors := errors.New("tests error")
-	gomock.InOrder(
-		suite.mockGit.EXPECT().CloneByTag(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors),
-	)
-
-	err := repo.Clone(c, suite.cloneDir)
-	assert.Error(suite.T(), err)
 }
 
 func (suite *RepositoryPublicTestSuite) TestCopySourcesOkWhenSourceIsDirAndDstDirDoesNotExist() {

--- a/test/integration/test_cli.bats
+++ b/test/integration/test_cli.bats
@@ -29,24 +29,19 @@ GILT_PROGRAM="../../../main.go"
 GILT_DIR=~/.gilt/clone
 
 setup() {
-	GILT_CLONED_REPO_1=${GILT_DIR}/cache/https---github.com-retr0h-ansible-etcd.git-77a95b7
-	GILT_CLONED_REPO_2=${GILT_DIR}/cache/https---github.com-retr0h-ansible-etcd.git-1.1
-	GILT_CLONED_REPO_3=${GILT_DIR}/cache/https---github.com-lorin-openstack-ansible-modules.git-2677cc3
+	GILT_CLONED_REPO=${GILT_DIR}/cache/ansible-etcd.git
 
 	GILT_CLONED_REPO_1_DST_DIR=${GILT_TEST_BASE_TMP_DIR}/retr0h.ansible-etcd
 	GILT_CLONED_REPO_2_DST_DIR=${GILT_TEST_BASE_TMP_DIR}/retr0h.ansible-etcd-tag
 
-  mkdir -p ${GILT_DIR}
-
+    mkdir -p ${GILT_DIR}
 	mkdir -p ${GILT_LIBRARY_DIR}
 	mkdir -p ${GILT_ROLES_DIR}
 	cp test/Giltfile.yaml ${GILT_TEST_BASE_TMP_DIR}/Giltfile.yaml
 }
 
 teardown() {
-	rm -rf ${GILT_CLONED_REPO_1}
-	rm -rf ${GILT_CLONED_REPO_2}
-	rm -rf ${GILT_CLONED_REPO_3}
+	rm -rf ${GILT_CLONED_REPO}
 	rm -rf ${GILT_CLONED_REPO_1_DST_DIR}
 	rm -rf ${GILT_CLONED_REPO_2_DST_DIR}
 
@@ -113,7 +108,7 @@ teardown() {
 
 	[ "$status" -eq 0 ]
 	echo "${output}" | grep "[https://github.com/retr0h/ansible-etcd.git@77a95b7]"
-	echo "${output}" | grep -E ".*cloning.*https---github.com-retr0h-ansible-etcd.git-77a95b7"
+	echo "${output}" | grep -E ".*Preparing worktree.*HEAD is now at 77a95b7"
 }
 
 @test "invoke gilt overlay when already cloned" {
@@ -126,13 +121,7 @@ teardown() {
 @test "invoke gilt overlay and clone" {
 	run bash -c "cd ${GILT_TEST_BASE_TMP_DIR}; go run ${GILT_PROGRAM} overlay"
 
-	run stat ${GILT_CLONED_REPO_1}
-	[ "$status" = 0 ]
-
-	run stat ${GILT_CLONED_REPO_2}
-	[ "$status" = 0 ]
-
-	run stat ${GILT_CLONED_REPO_3}
+	run stat ${GILT_CLONED_REPO}
 	[ "$status" = 0 ]
 }
 


### PR DESCRIPTION
- Clone repositories into the cache with `--bare` to keep just the repo objects in cache, rather than an unused copy of the working tree.  This can yield a significant space savings in repositories with large numbers of files
- Clone repositories into the cache with `--filter=blob:none`.  This will skip downloading any objects from the repository in the initial copy of the clone, and only populate the repository metadata; subsequent operations will automatically download the required objects (and ONLY the required objects) from origin as needed.  This yields a massive space/performance boost.
- Make use of the `git worktree` subcommand to populate `dstDir` targets rather than `git checkout-index`.  This subcommand is designed for using a single repository as a source for multiple copies of the working tree, so it is a much better fit for what Gilt is trying to do.
- Remove the now-obsolete `CloneByTag`, `Reset`, and `CheckoutIndex` workflows.

With this change, the `tag:` and `sha:` directives in `Giltfile.yaml` become 100% equivalent, with no difference in handling required.

Fixes: Issue #70