### PR TITLE
feat: merge tag and sha fields into version

### DIFF
--- a/Giltfile.yaml
+++ b/Giltfile.yaml
@@ -3,13 +3,13 @@ giltDir: ~/.gilt/clone
 debug: false
 repositories:
   - git: https://github.com/retr0h/ansible-etcd.git
-    sha: 77a95b7
+    version: 77a95b7
     dstDir: /tmp/retr0h.ansible-etcd
   - git: https://github.com/retr0h/ansible-etcd.git
-    tag: 1.1
+    version: 1.1
     dstDir: /tmp/retr0h.ansible-etcd
   - git: https://github.com/lorin/openstack-ansible-modules.git
-    sha: 2677cc3
+    version: 2677cc3
     sources:
       - src: "*_manage"
         dstDir: /tmp/library

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -20,13 +20,13 @@ giltDir: ~/.gilt/clone
 debug: false
 repositories:
   - git: https://github.com/retr0h/ansible-etcd.git
-    sha: 77a95b7
+    version: 77a95b7
     dstDir: roles/retr0h.ansible-etcd
   - git: https://github.com/retr0h/ansible-etcd.git
-    tag: 1.1
+    version: 1.1
     dstDir: roles/retr0h.ansible-etcd-tag
   - git: https://github.com/lorin/openstack-ansible-modules.git
-    sha: 2677cc3
+    version: 2677cc3
     sources:
       - src: "*_manage"
         dstDir: library

--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -39,7 +39,7 @@ func main() {
 		Repositories: []config.Repository{
 			{
 				Git:     "https://github.com/retr0h/ansible-etcd.git",
-				SHA:     "77a95b7",
+				Version: "77a95b7",
 				DstDir:  "../tmp/retr0h.ansible-etcd",
 			},
 		},

--- a/examples/go-client/go.mod
+++ b/examples/go-client/go.mod
@@ -2,7 +2,7 @@ module example.com/client
 
 go 1.21.0
 
-replace github.com/retr0h/go-gilt v0.0.0 => ../../../go-gilt/
+replace github.com/retr0h/go-gilt => ../../../go-gilt/
 
 require (
 	github.com/lmittmann/tint v1.0.3

--- a/examples/go-client/go.sum
+++ b/examples/go-client/go.sum
@@ -23,8 +23,6 @@ github.com/lmittmann/tint v1.0.3/go.mod h1:HIS3gSy7qNwGCj+5oRjAutErFBl4BzdQP6cJZ
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/retr0h/go-gilt v1.0.2 h1:WBl+x23HnJXwmcpTRom9vcnrvICQUffU2oC6znLTf0E=
-github.com/retr0h/go-gilt v1.0.2/go.mod h1:7YrTY3MuqXXCh7009FHglJQ0U2XVnJ8K2CMiIGdSp0A=
 github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=
 github.com/spf13/afero v1.11.0/go.mod h1:GH9Y3pIexgf1MTIWtNGyogA5MwRIDXGUr+hbWNoBjkY=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -35,8 +33,6 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-golang.org/x/crypto v0.16.0 h1:mMMrFzRSCF0GvB7Ne27XVtVAaXLrPmgPC7/v0tkwHaY=
-golang.org/x/crypto v0.16.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
 golang.org/x/crypto v0.17.0 h1:r8bRNjWL3GshPW3gkd+RpvzWrZAwPS49OmTGZ/uhM4k=
 golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
 golang.org/x/net v0.19.0 h1:zTwKpTd2XuCqf8huc7Fo2iSy+4RHPd10s4KzeTnVr1c=

--- a/examples/go-client/main.go
+++ b/examples/go-client/main.go
@@ -40,9 +40,9 @@ func main() {
 		GiltDir: "~/.gilt",
 		Repositories: []config.Repository{
 			{
-				Git:    "https://github.com/retr0h/ansible-etcd.git",
-				SHA:    "77a95b7",
-				DstDir: "../../test/integration/tmp/retr0h.ansible-etcd",
+				Git:     "https://github.com/retr0h/ansible-etcd.git",
+				Version: "77a95b7",
+				DstDir:  "../../test/integration/tmp/retr0h.ansible-etcd",
 			},
 		},
 	}

--- a/internal/git/git_public_test.go
+++ b/internal/git/git_public_test.go
@@ -42,11 +42,10 @@ type GitManagerPublicTestSuite struct {
 	ctrl     *gomock.Controller
 	mockExec *exec.MockExecManager
 
-	gitURL   string
-	gitSHA   string
-	gitTag   string
-	cloneDir string
-	dstDir   string
+	gitURL     string
+	gitVersion string
+	cloneDir   string
+	dstDir     string
 
 	gm internal.GitManager
 }
@@ -66,8 +65,7 @@ func (suite *GitManagerPublicTestSuite) SetupTest() {
 	defer suite.ctrl.Finish()
 
 	suite.gitURL = "https://example.com/user/repo.git"
-	suite.gitSHA = "abc123"
-	suite.gitTag = "v1.1"
+	suite.gitVersion = "abc123"
 	suite.cloneDir = "/cloneDir"
 	suite.dstDir = "/dstDir"
 
@@ -93,18 +91,18 @@ func (suite *GitManagerPublicTestSuite) TestCloneReturnsError() {
 
 func (suite *GitManagerPublicTestSuite) TestWorktreeOk() {
 	suite.mockExec.EXPECT().
-		RunCmdInDir("git", []string{"worktree", "add", "--force", suite.dstDir, suite.gitSHA}, suite.cloneDir).
+		RunCmdInDir("git", []string{"worktree", "add", "--force", suite.dstDir, suite.gitVersion}, suite.cloneDir).
 		Return(nil)
-	err := suite.gm.Worktree(suite.cloneDir, suite.gitSHA, suite.dstDir)
+	err := suite.gm.Worktree(suite.cloneDir, suite.gitVersion, suite.dstDir)
 	assert.NoError(suite.T(), err)
 }
 
 func (suite *GitManagerPublicTestSuite) TestWorktreeError() {
 	errors := errors.New("tests error")
 	suite.mockExec.EXPECT().
-		RunCmdInDir("git", []string{"worktree", "add", "--force", suite.dstDir, suite.gitSHA}, suite.cloneDir).
+		RunCmdInDir("git", []string{"worktree", "add", "--force", suite.dstDir, suite.gitVersion}, suite.cloneDir).
 		Return(errors)
-	err := suite.gm.Worktree(suite.cloneDir, suite.gitSHA, suite.dstDir)
+	err := suite.gm.Worktree(suite.cloneDir, suite.gitVersion, suite.dstDir)
 	assert.Error(suite.T(), err)
 }
 

--- a/internal/repositories/repositories_public_test.go
+++ b/internal/repositories/repositories_public_test.go
@@ -50,7 +50,7 @@ type RepositoriesPublicTestSuite struct {
 	dstDir           string
 	giltDir          string
 	gitURL           string
-	gitSHA           string
+	gitVersion       string
 	repoConfigDstDir []config.Repository
 	logger           *slog.Logger
 }
@@ -84,12 +84,12 @@ func (suite *RepositoriesPublicTestSuite) SetupTest() {
 	suite.dstDir = "/dstDir"
 	suite.giltDir = "/giltDir"
 	suite.gitURL = "https://example.com/user/repo.git"
-	suite.gitSHA = "abc1234"
+	suite.gitVersion = "abc1234"
 	suite.repoConfigDstDir = []config.Repository{
 		{
-			Git:    suite.gitURL,
-			SHA:    suite.gitSHA,
-			DstDir: suite.dstDir,
+			Git:     suite.gitURL,
+			Version: suite.gitVersion,
+			DstDir:  suite.dstDir,
 		},
 	}
 
@@ -140,8 +140,8 @@ func (suite *RepositoriesPublicTestSuite) TestOverlayReturnsErrorWhenCloneErrors
 func (suite *RepositoriesPublicTestSuite) TestOverlayOkWhenCopySources() {
 	repoConfig := []config.Repository{
 		{
-			Git: suite.gitURL,
-			SHA: suite.gitSHA,
+			Git:     suite.gitURL,
+			Version: suite.gitVersion,
 			Sources: []config.Source{
 				{
 					Src:    "srcDir",
@@ -164,8 +164,8 @@ func (suite *RepositoriesPublicTestSuite) TestOverlayOkWhenCopySources() {
 func (suite *RepositoriesPublicTestSuite) TestOverlayReturnsErrorWhenCopySourcesErrors() {
 	repoConfig := []config.Repository{
 		{
-			Git: suite.gitURL,
-			SHA: suite.gitSHA,
+			Git:     suite.gitURL,
+			Version: suite.gitVersion,
 			Sources: []config.Source{
 				{
 					Src:    "srcDir",
@@ -189,9 +189,9 @@ func (suite *RepositoriesPublicTestSuite) TestOverlayReturnsErrorWhenCopySources
 func (suite *RepositoriesPublicTestSuite) TestOverlayOkWhenCommands() {
 	repoConfig := []config.Repository{
 		{
-			Git:    suite.gitURL,
-			SHA:    suite.gitSHA,
-			DstDir: suite.dstDir,
+			Git:     suite.gitURL,
+			Version: suite.gitVersion,
+			DstDir:  suite.dstDir,
 			Commands: []config.Command{
 				{
 					Cmd:  "touch",
@@ -214,9 +214,9 @@ func (suite *RepositoriesPublicTestSuite) TestOverlayOkWhenCommands() {
 func (suite *RepositoriesPublicTestSuite) TestOverlayReturnsErrorWhenCommandErrors() {
 	repoConfig := []config.Repository{
 		{
-			Git:    suite.gitURL,
-			SHA:    suite.gitSHA,
-			DstDir: suite.dstDir,
+			Git:     suite.gitURL,
+			Version: suite.gitVersion,
+			DstDir:  suite.dstDir,
 			Commands: []config.Command{
 				{
 					Cmd:  "touch",

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -108,13 +108,7 @@ func (r *Repository) Worktree(
 	cloneDir string,
 	targetDir string,
 ) error {
-	var version string
-	if c.SHA != "" {
-		version = c.SHA
-	} else {
-		version = c.Tag
-	}
-	return r.gitManager.Worktree(cloneDir, version, targetDir)
+	return r.gitManager.Worktree(cloneDir, c.Version, targetDir)
 }
 
 // CopySources copy Repository.Src to Repository.DstFile or Repository.DstDir.

--- a/internal/repository/repository_public_test.go
+++ b/internal/repository/repository_public_test.go
@@ -83,8 +83,8 @@ func (suite *RepositoryPublicTestSuite) TestCloneOk() {
 	repo := suite.NewRepositoryManager()
 
 	c := config.Repository{
-		Git: suite.gitURL,
-		SHA: suite.gitSHA,
+		Git:     suite.gitURL,
+		Version: suite.gitSHA,
 	}
 	targetDir := filepath.Join(suite.cloneDir, filepath.Base(c.Git))
 
@@ -100,8 +100,8 @@ func (suite *RepositoryPublicTestSuite) TestCloneReturnsErrorWhenCloneErrors() {
 	repo := suite.NewRepositoryManager()
 
 	c := config.Repository{
-		Git: suite.gitURL,
-		SHA: suite.gitSHA,
+		Git:     suite.gitURL,
+		Version: suite.gitSHA,
 	}
 
 	errors := errors.New("tests error")
@@ -117,8 +117,8 @@ func (suite *RepositoryPublicTestSuite) TestCloneDoesNotCloneWhenCloneDirExists(
 	repo := suite.NewRepositoryManager()
 
 	c := config.Repository{
-		Git: suite.gitURL,
-		SHA: suite.gitSHA,
+		Git:     suite.gitURL,
+		Version: suite.gitSHA,
 	}
 	targetDir := filepath.Join(suite.cloneDir, filepath.Base(c.Git))
 
@@ -140,8 +140,8 @@ func (suite *RepositoryPublicTestSuite) TestCopySourcesOkWhenSourceIsDirAndDstDi
 	createFileSpecs(specs)
 
 	c := config.Repository{
-		Git: suite.gitURL,
-		SHA: suite.gitSHA,
+		Git:     suite.gitURL,
+		Version: suite.gitSHA,
 		Sources: []config.Source{
 			{
 				Src:    filepath.Base(specs[0].srcDir),
@@ -170,8 +170,8 @@ func (suite *RepositoryPublicTestSuite) TestCopySourcesReturnsErrorWhenSourceIsD
 	createFileSpecs(specs)
 
 	c := config.Repository{
-		Git: suite.gitURL,
-		SHA: suite.gitSHA,
+		Git:     suite.gitURL,
+		Version: suite.gitSHA,
 		Sources: []config.Source{
 			{
 				Src:    filepath.Base(specs[0].srcDir),
@@ -199,8 +199,8 @@ func (suite *RepositoryPublicTestSuite) TestCopySourcesOkWhenSourceIsDirAndDstDi
 	createFileSpecs(specs)
 
 	c := config.Repository{
-		Git: suite.gitURL,
-		SHA: suite.gitSHA,
+		Git:     suite.gitURL,
+		Version: suite.gitSHA,
 		Sources: []config.Source{
 			{
 				Src:    filepath.Base(specs[0].srcDir),
@@ -246,8 +246,8 @@ func (suite *RepositoryPublicTestSuite) TestCopySourcesOkWhenSourceIsFilesAndDst
 	createFileSpecs(specs)
 
 	c := config.Repository{
-		Git: suite.gitURL,
-		SHA: suite.gitSHA,
+		Git:     suite.gitURL,
+		Version: suite.gitSHA,
 		Sources: []config.Source{
 			{
 				Src:    "subDir/*_manage",
@@ -298,8 +298,8 @@ func (suite *RepositoryPublicTestSuite) TestCopySourcesReturnsErrorWhenSourceIsF
 	createFileSpecs(specs)
 
 	c := config.Repository{
-		Git: suite.gitURL,
-		SHA: suite.gitSHA,
+		Git:     suite.gitURL,
+		Version: suite.gitSHA,
 		Sources: []config.Source{
 			{
 				Src:    "subDir/*.txt",
@@ -327,8 +327,8 @@ func (suite *RepositoryPublicTestSuite) TestCopySourcesOkWhenSourceIsFileAndDstF
 	createFileSpecs(specs)
 
 	c := config.Repository{
-		Git: suite.gitURL,
-		SHA: suite.gitSHA,
+		Git:     suite.gitURL,
+		Version: suite.gitSHA,
 		Sources: []config.Source{
 			{
 				Src:     "1.txt",
@@ -357,8 +357,8 @@ func (suite *RepositoryPublicTestSuite) TestCopySourcesReturnsErrorWhenSourceIsF
 	createFileSpecs(specs)
 
 	c := config.Repository{
-		Git: suite.gitURL,
-		SHA: suite.gitSHA,
+		Git:     suite.gitURL,
+		Version: suite.gitSHA,
 		Sources: []config.Source{
 			{
 				Src:     "1.txt",
@@ -377,9 +377,9 @@ func (suite *RepositoryPublicTestSuite) TestCopySourcesReturnsErrorWhenSourceIsF
 func (suite *RepositoryPublicTestSuite) TestWorktreeTagOk() {
 	repo := suite.NewRepositoryManager()
 	c := config.Repository{
-		Tag: suite.gitTag,
+		Version: suite.gitTag,
 	}
-	suite.mockGit.EXPECT().Worktree(suite.cloneDir, c.Tag, suite.dstDir).Return(nil)
+	suite.mockGit.EXPECT().Worktree(suite.cloneDir, c.Version, suite.dstDir).Return(nil)
 
 	err := repo.Worktree(c, suite.cloneDir, suite.dstDir)
 	assert.NoError(suite.T(), err)
@@ -389,10 +389,9 @@ func (suite *RepositoryPublicTestSuite) TestWorktreeSHAOk() {
 	repo := suite.NewRepositoryManager()
 	// Implicitly test that SHA overrides Tag
 	c := config.Repository{
-		Tag: suite.gitTag,
-		SHA: suite.gitSHA,
+		Version: suite.gitSHA,
 	}
-	suite.mockGit.EXPECT().Worktree(suite.cloneDir, c.SHA, suite.dstDir).Return(nil)
+	suite.mockGit.EXPECT().Worktree(suite.cloneDir, c.Version, suite.dstDir).Return(nil)
 
 	err := repo.Worktree(c, suite.cloneDir, suite.dstDir)
 	assert.NoError(suite.T(), err)

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -21,20 +21,13 @@
 package config
 
 import (
-	"regexp"
-
 	"github.com/go-playground/validator/v10"
 )
 
 // registerValidators register customer validators.
 func registerValidators(v *validator.Validate) error {
-	return v.RegisterValidation("git_sha", func(fl validator.FieldLevel) bool {
-		if fl.Field().String() == "" {
-			return true
-		}
-		re := regexp.MustCompile("^[0-9a-f]{5,40}$")
-		return re.MatchString(fl.Field().String())
-	})
+	// noop - hook for future validators
+	return nil
 }
 
 // Validate validates a structs exposed fields.

--- a/pkg/config/schema_test.go
+++ b/pkg/config/schema_test.go
@@ -51,9 +51,9 @@ func (suite *SchemaTestSuite) TestRepositories() {
 			GiltDir:  "giltDir",
 			Repositories: []Repository{
 				{
-					Git:    "gitURL",
-					SHA:    "abc1234",
-					DstDir: "dstDir",
+					Git:     "gitURL",
+					Version: "abc1234",
+					DstDir:  "dstDir",
 				},
 			},
 		}, ""},
@@ -62,9 +62,9 @@ func (suite *SchemaTestSuite) TestRepositories() {
 			GiltDir:  "",
 			Repositories: []Repository{
 				{
-					Git:    "gitURL",
-					SHA:    "abc1234",
-					DstDir: "dstDir",
+					Git:     "gitURL",
+					Version: "abc1234",
+					DstDir:  "dstDir",
 				},
 			},
 		}, "Key: 'Repositories.GiltDir' Error:Field validation for 'GiltDir' failed on the 'required' tag"},
@@ -73,9 +73,9 @@ func (suite *SchemaTestSuite) TestRepositories() {
 			GiltDir:  "giltDir",
 			Repositories: []Repository{
 				{
-					Git:    "gitURL",
-					SHA:    "abc1234",
-					DstDir: "dstDir",
+					Git:     "gitURL",
+					Version: "abc1234",
+					DstDir:  "dstDir",
 				},
 			},
 		}, "Key: 'Repositories.GiltFile' Error:Field validation for 'GiltFile' failed on the 'required' tag"},
@@ -165,18 +165,18 @@ func (suite *SchemaTestSuite) TestRepositorySchema() {
 		expected string
 	}{
 		{&Repository{
-			Git:    "gitURL",
-			SHA:    "abc1234",
-			DstDir: "dstDir",
+			Git:     "gitURL",
+			Version: "abc1234",
+			DstDir:  "dstDir",
 		}, ""},
 		{&Repository{
-			Git:    "gitURL",
-			Tag:    "v1.1",
-			DstDir: "dstDir",
+			Git:     "gitURL",
+			Version: "v1.1",
+			DstDir:  "dstDir",
 		}, ""},
 		{&Repository{
-			Git: "gitURL",
-			SHA: "abc1234",
+			Git:     "gitURL",
+			Version: "abc1234",
 			Sources: []Source{
 				{
 					Src:     "src",
@@ -185,20 +185,14 @@ func (suite *SchemaTestSuite) TestRepositorySchema() {
 			},
 		}, ""},
 		{&Repository{
-			Git:    "gitURL",
-			SHA:    "abc1234",
-			Tag:    "v1.1",
-			DstDir: "dstDir",
-		}, "Key: 'Repository.SHA' Error:Field validation for 'SHA' failed on the 'excluded_with' tag\nKey: 'Repository.Tag' Error:Field validation for 'Tag' failed on the 'excluded_with' tag"},
+			Git:     "gitURL",
+			Version: "",
+			DstDir:  "dstDir",
+		}, "Key: 'Repository.Version' Error:Field validation for 'Version' failed on the 'required' tag"},
 		{&Repository{
-			Git:    "",
-			SHA:    "foo",
-			DstDir: "",
-		}, "Key: 'Repository.Git' Error:Field validation for 'Git' failed on the 'required' tag\nKey: 'Repository.SHA' Error:Field validation for 'SHA' failed on the 'git_sha' tag\nKey: 'Repository.DstDir' Error:Field validation for 'DstDir' failed on the 'required_without' tag"},
-		{&Repository{
-			Git:    "gitURL",
-			SHA:    "abc1234",
-			DstDir: "dstDir",
+			Git:     "gitURL",
+			Version: "abc1234",
+			DstDir:  "dstDir",
 			Sources: []Source{
 				{
 					Src:     "src",

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -54,10 +54,8 @@ type Command struct {
 type Repository struct {
 	// Git url of Git repository to clone.
 	Git string `mapstructure:"git"      validate:"required"`
-	// SHA the commit SHA to use.
-	SHA string `mapstructure:"sha"      validate:"git_sha,required_without=Tag,excluded_with=Tag"`
-	// Tag the tag to use.
-	Tag string `mapstructure:"tag"      validate:"required_without=SHA,excluded_with=SHA"`
+	// Version the commit SHA or tag to use.
+	Version string `mapstructure:"version"  validate:"required"`
 	// DstDir destination directory to copy clone to.
 	DstDir string `mapstructure:"dstDir"   validate:"required_without=Sources,excluded_with=Sources"`
 	// Sources containing files and/or directories to copy.

--- a/pkg/repositories/repositories.go
+++ b/pkg/repositories/repositories.go
@@ -147,7 +147,7 @@ func (r *Repositories) logRepositoriesGroup() []any {
 
 		group := slog.Group(strconv.Itoa(i),
 			slog.String("Git", repo.Git),
-			slog.String("SHA", repo.SHA),
+			slog.String("Version", repo.Version),
 			slog.String("DstDir", repo.DstDir),
 			slog.Group("Sources", sourceGroups...),
 			slog.Group("Commands", cmdGroups...),

--- a/test/Giltfile.yaml
+++ b/test/Giltfile.yaml
@@ -1,16 +1,16 @@
 ---
 repositories:
   - git: https://github.com/retr0h/ansible-etcd.git
-    sha: 77a95b7
+    version: 77a95b7
     dstDir: retr0h.ansible-etcd
     commands:
       - cmd: touch
         args: ansible-etcd-repo-post-command-1
   - git: https://github.com/retr0h/ansible-etcd.git
-    tag: 1.1
+    version: 1.1
     dstDir: retr0h.ansible-etcd-tag
   - git: https://github.com/lorin/openstack-ansible-modules.git
-    sha: 2677cc3
+    version: 2677cc3
     sources:
       - src: "*_manage"
         dstDir: library


### PR DESCRIPTION
Commit d306437a045ae878a85d249282dbc838ce2ada77 made the handling of these two fields 100% equivalent.

Breaking change will need to migrate `Giltfile.yaml` `repositories.tag` and/or `repositories.sha` to `repositories.version`

From:

```yaml
repositories:
  - git: https://github.com/retr0h/ansible-etcd.git
    sha: 77a95b7
    dstDir: /tmp/retr0h.ansible-etcd
  - git: https://github.com/retr0h/ansible-etcd.git
    tag: 1.1
    dstDir: /tmp/retr0h.ansible-etcd-tag
```

To:

```yaml
repositories:
  - git: https://github.com/retr0h/ansible-etcd.git
    version: 77a95b7
    dstDir: /tmp/retr0h.ansible-etcd
  - git: https://github.com/retr0h/ansible-etcd.git
    version: 1.1
    dstDir: /tmp/retr0h.ansible-etcd-tag
```

Fixes: #74