### PR TITLE
fix: log the entire post-command being run

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	go.hein.dev/go-version v0.1.0
 	golang.org/x/term v0.15.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -43,6 +44,5 @@ require (
 	golang.org/x/text v0.14.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -29,11 +29,9 @@ import (
 
 // New factory to create a new Exec instance.
 func New(
-	debug bool,
 	logger *slog.Logger,
 ) *Exec {
 	return &Exec{
-		debug:  debug,
 		logger: logger,
 	}
 }

--- a/internal/exec/exec_public_test.go
+++ b/internal/exec/exec_public_test.go
@@ -36,11 +36,8 @@ type ExecManagerPublicTestSuite struct {
 	suite.Suite
 }
 
-func (suite *ExecManagerPublicTestSuite) NewTestExecManager(
-	debug bool,
-) internal.ExecManager {
+func (suite *ExecManagerPublicTestSuite) NewTestExecManager() internal.ExecManager {
 	return exec.New(
-		debug,
 		slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 			Level: slog.LevelDebug,
 		})),
@@ -48,7 +45,7 @@ func (suite *ExecManagerPublicTestSuite) NewTestExecManager(
 }
 
 func (suite *ExecManagerPublicTestSuite) TestRunCmdOk() {
-	em := suite.NewTestExecManager(false)
+	em := suite.NewTestExecManager()
 
 	err := em.RunCmd("ls", []string{})
 	assert.NoError(suite.T(), err)
@@ -57,14 +54,14 @@ func (suite *ExecManagerPublicTestSuite) TestRunCmdOk() {
 func (suite *ExecManagerPublicTestSuite) TestRunCmdWithDebug() {
 	suite.T().Skip("cannot seem to capture Stdout when logging in em")
 
-	em := suite.NewTestExecManager(true)
+	em := suite.NewTestExecManager()
 
 	err := em.RunCmd("echo", []string{"-n", "foo"})
 	assert.NoError(suite.T(), err)
 }
 
 func (suite *ExecManagerPublicTestSuite) TestRunCmdReturnsError() {
-	em := suite.NewTestExecManager(false)
+	em := suite.NewTestExecManager()
 
 	err := em.RunCmd("invalid", []string{"foo"})
 	assert.Error(suite.T(), err)
@@ -72,7 +69,7 @@ func (suite *ExecManagerPublicTestSuite) TestRunCmdReturnsError() {
 }
 
 func (suite *ExecManagerPublicTestSuite) TestRunCmdInDirOk() {
-	em := suite.NewTestExecManager(false)
+	em := suite.NewTestExecManager()
 
 	err := em.RunCmdInDir("ls", []string{}, "/tmp")
 	assert.NoError(suite.T(), err)
@@ -81,14 +78,14 @@ func (suite *ExecManagerPublicTestSuite) TestRunCmdInDirOk() {
 func (suite *ExecManagerPublicTestSuite) TestRunCmdInDirWithDebug() {
 	suite.T().Skip("cannot seem to capture Stdout when logging in em")
 
-	em := suite.NewTestExecManager(true)
+	em := suite.NewTestExecManager()
 
 	err := em.RunCmdInDir("echo", []string{"-n", "foo"}, "/tmp")
 	assert.NoError(suite.T(), err)
 }
 
 func (suite *ExecManagerPublicTestSuite) TestRunCmdInDirReturnsError() {
-	em := suite.NewTestExecManager(false)
+	em := suite.NewTestExecManager()
 
 	err := em.RunCmdInDir("invalid", []string{"foo"}, "/tmp")
 	assert.Error(suite.T(), err)
@@ -96,7 +93,7 @@ func (suite *ExecManagerPublicTestSuite) TestRunCmdInDirReturnsError() {
 }
 
 func (suite *ExecManagerPublicTestSuite) TestRunInTempDirOk() {
-	em := suite.NewTestExecManager(false)
+	em := suite.NewTestExecManager()
 
 	dir := ""
 	pattern := "test"
@@ -107,7 +104,7 @@ func (suite *ExecManagerPublicTestSuite) TestRunInTempDirOk() {
 }
 
 func (suite *ExecManagerPublicTestSuite) TestRunInTempDirError() {
-	em := suite.NewTestExecManager(false)
+	em := suite.NewTestExecManager()
 
 	dir := "\x00" // Null character is invalid in a filepath
 	pattern := "test"

--- a/internal/exec/types.go
+++ b/internal/exec/types.go
@@ -26,6 +26,5 @@ import (
 
 // Exec disk implementation.
 type Exec struct {
-	debug  bool
 	logger *slog.Logger
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -36,13 +36,11 @@ import (
 // New factory to create a new Git instance.
 func New(
 	appFs afero.Fs,
-	debug bool,
 	execManager internal.ExecManager,
 	logger *slog.Logger,
 ) *Git {
 	return &Git{
 		appFs:       appFs,
-		debug:       debug,
 		execManager: execManager,
 		logger:      logger,
 	}

--- a/internal/git/git_public_test.go
+++ b/internal/git/git_public_test.go
@@ -53,7 +53,6 @@ type GitManagerPublicTestSuite struct {
 func (suite *GitManagerPublicTestSuite) NewTestGitManager() internal.GitManager {
 	return git.New(
 		afero.NewMemMapFs(),
-		false,
 		suite.mockExec,
 		slog.New(slog.NewTextHandler(os.Stdout, nil)),
 	)

--- a/internal/git/types.go
+++ b/internal/git/types.go
@@ -31,7 +31,6 @@ import (
 // Git implementation responsible for Git operations.
 type Git struct {
 	appFs       afero.Fs
-	debug       bool
 	execManager internal.ExecManager
 	logger      *slog.Logger
 }

--- a/internal/repositories/repositories.go
+++ b/internal/repositories/repositories.go
@@ -24,6 +24,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/afero"
 
@@ -129,8 +130,9 @@ func (r *Repositories) Overlay() error {
 		if len(c.Commands) > 0 {
 			for _, command := range c.Commands {
 				r.logger.Info(
-					"executing commmand",
+					"executing command",
 					slog.String("cmd", command.Cmd),
+					slog.String("args", strings.Join(command.Args, " ")),
 				)
 				if err := r.execManager.RunCmd(command.Cmd, command.Args); err != nil {
 					return err

--- a/pkg/repositories/repositories.go
+++ b/pkg/repositories/repositories.go
@@ -51,13 +51,11 @@ func New(
 	)
 
 	execManager := exec.New(
-		c.Debug,
 		logger,
 	)
 
 	gitManager := git.New(
 		appFs,
-		c.Debug,
 		execManager,
 		logger,
 	)


### PR DESCRIPTION
When running post-commands, log both the command and all defined args, to aid troubleshooting.

chore: correct a typo that was gumming up the Go Report Card

refactor: remove unused `debug` attribute from managers

This appears to be a vestigial; there's a logger object available everywhere, and checking the log level is easier than setting this flag everywhere
