### PR TITLE
fix: enable debug output via `debug: true` in the config file

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -135,6 +135,9 @@ func initConfig(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
+	// The value for `debug` might have changed; re-initialize the logger
+	initLogger()
+
 	repos = repositories.New(
 		appConfig,
 		logger,


### PR DESCRIPTION
Re-initialize the logger after the config file is loaded, to pick up any new values.

Fixes: Issue #114