### PR TITLE
chore: refactor initLogger()

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -56,30 +56,33 @@ current working directory.`,
 		ye := yaml.NewEncoder(&b)
 		ye.SetIndent(2)
 		if err := ye.Encode(c); err != nil {
-			logger.Error(
+			logFatal(
 				"failed to encode file",
-				slog.String("err", err.Error()),
+				slog.Group("",
+					slog.String("err", err.Error()),
+				),
 			)
-			os.Exit(1)
 		}
 
 		configFile := viper.GetString("giltFile")
 		_, err := os.Stat(configFile)
 		if err == nil {
-			logger.Error(
+			logFatal(
 				"file already exists",
-				slog.String("Giltfile", configFile),
+				slog.Group("",
+					slog.String("Giltfile", configFile),
+				),
 			)
-			os.Exit(1)
 		}
 
-		if err := os.WriteFile(configFile, b.Bytes(), 0o666); err != nil {
-			logger.Error(
+		if err := os.WriteFile(configFile, b.Bytes(), 0o644); err != nil {
+			logFatal(
 				"failed to write file",
-				slog.String("Giltfile", viper.ConfigFileUsed()),
-				slog.String("err", err.Error()),
+				slog.Group("",
+					slog.String("Giltfile", viper.ConfigFileUsed()),
+					slog.String("err", err.Error()),
+				),
 			)
-			os.Exit(1)
 		}
 
 		fmt.Printf("wrote %s\n", configFile)

--- a/cmd/overlay.go
+++ b/cmd/overlay.go
@@ -22,6 +22,8 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/retr0h/go-gilt/pkg/repositories"
 )
 
 // overlayCmd represents the overlay command
@@ -30,7 +32,6 @@ var overlayCmd = &cobra.Command{
 	Short: "Install Gilt dependencies",
 	Long: `Overlay the repositories from the Giltfile into their respective
 destinations.`,
-	PersistentPreRun: initConfig,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// By the time we reach this point, we know that the arguments were
 		// properly parsed, and we don't want to show the usage if an error
@@ -39,6 +40,13 @@ destinations.`,
 		// We are logging errors, no need for cobra to re-log the error
 		cmd.SilenceErrors = true
 
+		initConfig()
+		initLogger()
+
+		repos := repositories.New(
+			appConfig,
+			logger,
+		)
 		return repos.Overlay()
 	},
 }

--- a/test/integration/test_cli.bats
+++ b/test/integration/test_cli.bats
@@ -64,7 +64,7 @@ teardown() {
 
 	[ "$status" -eq 0 ]
 	echo "${output}" | jq '.date'
-	echo "${output}" | jq '.build'
+	echo "${output}" | jq '.commit'
 	echo "${output}" | jq '.version'
 }
 


### PR DESCRIPTION
Cleanup the excessive calls to initLogger().  This is only marginally better.